### PR TITLE
v3.0.0: Migrate to Microsoft.Data.SqlClient and modernize project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore --configuration Release
+
+      - name: Test
+        run: dotnet test --no-build --configuration Release --verbosity normal

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /ShahJe.Sql.Dapper.Extensions/.vs/ShahJe.Sql.Dapper.Extensions
 /.claude
 /.vs
+/ShahJe.Sql.Dapper.Extensions/.vs/ProjectEvaluation

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 /ShahJe.Sql.Dapper.Extensions/bin/Release
 /ShahJe.Sql.Dapper.Extensions.Tests/obj
 /ShahJe.Sql.Dapper.Extensions.Tests/bin
+/ShahJe.Sql.Dapper.Extensions/.vs/ShahJe.Sql.Dapper.Extensions
+/.claude
+/.vs

--- a/README.md
+++ b/README.md
@@ -1,4 +1,57 @@
 # DapperExtensions
-Helper methods GetOne, GetMany, GetScalar, GetScalarBool, GetScalarDate, NonQuery, GetOneAsync, GetManyAsync, GetScalarAsync, GetScalarBoolAsync, GetScalarDateAsync, NonQueryAsync
 
-Nuget package [https://www.nuget.org/packages/ShahJe.Sql.Dapper.Extensions](https://www.nuget.org/packages/ShahJe.Sql.Dapper.Extensions)
+[![CI](https://github.com/ShahJe/DapperExtensions/actions/workflows/ci.yml/badge.svg)](https://github.com/ShahJe/DapperExtensions/actions/workflows/ci.yml)
+
+Helper methods for Dapper: GetOne, GetMany, GetScalar, GetScalarBool, GetScalarDate, NonQuery, and their async counterparts.
+
+NuGet package: [ShahJe.Sql.Dapper.Extensions](https://www.nuget.org/packages/ShahJe.Sql.Dapper.Extensions)
+
+## Installation
+
+```bash
+dotnet add package ShahJe.Sql.Dapper.Extensions
+```
+
+## Quick Start
+
+### Register in DI
+
+```csharp
+// Sync repository
+services.AddScoped<IRepository>(_ => new Repository("your-connection-string"));
+
+// Async repository
+services.AddScoped<IAsyncRepository>(_ => new AsyncRepository("your-connection-string"));
+```
+
+### Usage
+
+```csharp
+public class MyService
+{
+    private readonly IAsyncRepository _repo;
+
+    public MyService(IAsyncRepository repo) => _repo = repo;
+
+    public async Task<IEnumerable<Customer>> GetCustomers()
+    {
+        var param = new DynamicParameters();
+        param.Add("@Active", true);
+        return await _repo.GetManyAsync<Customer>("GetActiveCustomers", param);
+    }
+
+    public async Task<Customer> GetCustomer(int id)
+    {
+        var param = new DynamicParameters();
+        param.Add("@Id", id);
+        return await _repo.GetOneAsync<Customer>("GetCustomerById", param);
+    }
+}
+```
+
+## Breaking Changes in v3.0.0
+
+- **`System.Data.SqlClient` replaced with `Microsoft.Data.SqlClient`** — update any direct references
+- **`Connection()` now returns `IDbConnection`** instead of `SqlConnection`
+- **`ConnectionAsync()` now returns `Task<IDbConnection>`** instead of `Task<SqlConnection>`
+- Target frameworks updated to `netstandard2.0`, `netstandard2.1`, and `net8.0`

--- a/ShahJe.Sql.Dapper.Extensions.Tests/ShahJe.Sql.Dapper.Extensions.Tests.csproj
+++ b/ShahJe.Sql.Dapper.Extensions.Tests/ShahJe.Sql.Dapper.Extensions.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -21,10 +21,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ShahJe.Sql.Dapper.Extensions.Tests/TestBase.cs
+++ b/ShahJe.Sql.Dapper.Extensions.Tests/TestBase.cs
@@ -1,16 +1,60 @@
+using Microsoft.Data.SqlClient;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.IO;
 
 namespace ShahJe.Sql.Dapper.Extensions.Tests
 {
     public abstract class TestBase
     {
-        protected const string ConnectionString = @"Data Source=(LocalDb)\MSSQLLocalDB;Initial Catalog=UnitTest;Integrated Security=SSPI;AttachDBFilename={0}\UnitTest.mdf";
+        protected const string ConnectionString = @"Data Source=(LocalDb)\MSSQLLocalDB;Initial Catalog=UnitTest;Integrated Security=SSPI;AttachDBFilename={0}UnitTest.mdf";
 
-        protected string Path => AppContext.BaseDirectory;
+        private static readonly string _dbDirectory;
+
+        protected string Path => _dbDirectory;
+
+        static TestBase()
+        {
+            var source = AppContext.BaseDirectory;
+            var tempDir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "DapperExtensionsTests");
+            Directory.CreateDirectory(tempDir);
+
+            DetachDatabase();
+
+            File.Copy(
+                System.IO.Path.Combine(source, "UnitTest.mdf"),
+                System.IO.Path.Combine(tempDir, "UnitTest.mdf"),
+                overwrite: true);
+            File.Copy(
+                System.IO.Path.Combine(source, "UnitTest_log.ldf"),
+                System.IO.Path.Combine(tempDir, "UnitTest_log.ldf"),
+                overwrite: true);
+
+            _dbDirectory = tempDir + System.IO.Path.DirectorySeparatorChar;
+        }
 
         public static void ClassSetup(TestContext context)
         {
+        }
+
+        private static void DetachDatabase()
+        {
+            try
+            {
+                using var conn = new SqlConnection(@"Data Source=(LocalDb)\MSSQLLocalDB;Integrated Security=SSPI");
+                conn.Open();
+                using var cmd = conn.CreateCommand();
+                cmd.CommandText = @"
+                    IF EXISTS (SELECT name FROM sys.databases WHERE name = 'UnitTest')
+                    BEGIN
+                        ALTER DATABASE [UnitTest] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+                        EXEC sp_detach_db 'UnitTest', 'true';
+                    END";
+                cmd.ExecuteNonQuery();
+            }
+            catch
+            {
+            }
         }
     }
 }

--- a/ShahJe.Sql.Dapper.Extensions.Tests/TestBase.cs
+++ b/ShahJe.Sql.Dapper.Extensions.Tests/TestBase.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 
 namespace ShahJe.Sql.Dapper.Extensions.Tests
@@ -7,13 +7,10 @@ namespace ShahJe.Sql.Dapper.Extensions.Tests
     {
         protected const string ConnectionString = @"Data Source=(LocalDb)\MSSQLLocalDB;Initial Catalog=UnitTest;Integrated Security=SSPI;AttachDBFilename={0}\UnitTest.mdf";
 
-        protected string Path => AppDomain.CurrentDomain.GetData("DataDirectory") as string;
+        protected string Path => AppContext.BaseDirectory;
 
         public static void ClassSetup(TestContext context)
         {
-            AppDomain.CurrentDomain.SetData(
-            "DataDirectory",
-            context.TestDeploymentDir);
-        }        
+        }
     }
 }

--- a/ShahJe.Sql.Dapper.Extensions.sln
+++ b/ShahJe.Sql.Dapper.Extensions.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30204.135
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ShahJe.Sql.Dapper.Extensions", "ShahJe.Sql.Dapper.Extensions.csproj", "{A71FE001-789E-4EC1-B906-587302F17E1F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ShahJe.Sql.Dapper.Extensions", "ShahJe.Sql.Dapper.Extensions\ShahJe.Sql.Dapper.Extensions.csproj", "{A71FE001-789E-4EC1-B906-587302F17E1F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShahJe.Sql.Dapper.Extensions.Tests", "..\ShahJe.Sql.Dapper.Extensions.Tests\ShahJe.Sql.Dapper.Extensions.Tests.csproj", "{21FCB754-252B-4E21-8983-8E2F67F1D9B1}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShahJe.Sql.Dapper.Extensions.Tests", "ShahJe.Sql.Dapper.Extensions.Tests\ShahJe.Sql.Dapper.Extensions.Tests.csproj", "{21FCB754-252B-4E21-8983-8E2F67F1D9B1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/ShahJe.Sql.Dapper.Extensions/AsyncRepository.cs
+++ b/ShahJe.Sql.Dapper.Extensions/AsyncRepository.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -17,7 +17,7 @@ namespace ShahJe.Sql.Dapper.Extensions
 			ConnectionString = sqlConnectionString;
         }
 
-		public async Task<SqlConnection> ConnectionAsync(bool mars = false)
+		public async Task<IDbConnection> ConnectionAsync(bool mars = false)
 		{
 			var connection = new SqlConnection(ConnectionString);
 			await connection.OpenAsync();

--- a/ShahJe.Sql.Dapper.Extensions/IAsyncRepository.cs
+++ b/ShahJe.Sql.Dapper.Extensions/IAsyncRepository.cs
@@ -2,14 +2,14 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Threading.Tasks;
 
 namespace ShahJe.Sql.Dapper.Extensions
 {
 	public interface IAsyncRepository
 	{
-		Task<SqlConnection> ConnectionAsync(bool mars = false);
+		Task<IDbConnection> ConnectionAsync(bool mars = false);
 
 		Task<TEntity> GetOneAsync<TEntity>(string sql, CommandType commandType = CommandType.StoredProcedure)
 			where TEntity : class;

--- a/ShahJe.Sql.Dapper.Extensions/IRepository.cs
+++ b/ShahJe.Sql.Dapper.Extensions/IRepository.cs
@@ -2,13 +2,13 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 
 namespace ShahJe.Sql.Dapper.Extensions
 {
 	public interface IRepository
 	{
-		SqlConnection Connection(bool mars = false);
+		IDbConnection Connection(bool mars = false);
 
 		TEntity GetOne<TEntity>(string sql, CommandType commandType = CommandType.StoredProcedure)
 			where TEntity : class;

--- a/ShahJe.Sql.Dapper.Extensions/Repository.cs
+++ b/ShahJe.Sql.Dapper.Extensions/Repository.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 
 namespace ShahJe.Sql.Dapper.Extensions
@@ -16,7 +16,7 @@ namespace ShahJe.Sql.Dapper.Extensions
 			ConnectionString = sqlConnectionString;
         }
 
-		public SqlConnection Connection(bool mars = false)
+		public IDbConnection Connection(bool mars = false)
 		{
 			var connection = new SqlConnection(ConnectionString);
 			connection.Open();

--- a/ShahJe.Sql.Dapper.Extensions/ShahJe.Sql.Dapper.Extensions.csproj
+++ b/ShahJe.Sql.Dapper.Extensions/ShahJe.Sql.Dapper.Extensions.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.0.0</Version>
+    <Version>3.0.0</Version>
     <Description>Helper methods GetOne, GetMany, GetScalar, GetScalarBool, GetScalarDate, NonQuery, GetOneAsync, GetManyAsync, GetScalarAsync, GetScalarBoolAsync, GetScalarDateAsync, NonQueryAsync</Description>
     <Authors>Shahid Syed</Authors>
     <Copyright>Shahid Syed</Copyright>
@@ -12,18 +12,23 @@
     <RepositoryUrl>https://github.com/ShahJe/DapperExtensions.git</RepositoryUrl>
     <RepositoryType>github</RepositoryType>
     <PackageTags>dapper helper sql</PackageTags>
-    <PackageReleaseNotes>Added support for async methods GetOneAsync, GetManyAsync, GetScalarAsync, GetScalarBoolAsync, GetScalarDateAsync, NonQueryAsync</PackageReleaseNotes>
-    <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <FileVersion>2.0.0.0</FileVersion>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReleaseNotes>v3.0.0 Breaking Changes: Migrated from System.Data.SqlClient to Microsoft.Data.SqlClient. Connection() and ConnectionAsync() now return IDbConnection instead of SqlConnection. Updated Dapper to latest. Added net8.0 target framework.</PackageReleaseNotes>
+    <AssemblyVersion>3.0.0.0</AssemblyVersion>
+    <FileVersion>3.0.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.0.35" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="Dapper" Version="2.1.35" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
   </ItemGroup>
 
   <ItemGroup>
     <None Include="..\LICENSE">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+    <None Include="..\README.md">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>


### PR DESCRIPTION
  - Replace System.Data.SqlClient with Microsoft.Data.SqlClient 5.2.2
  - Update Dapper 2.0.35 → 2.1.35
  - Change Connection()/ConnectionAsync() return types to IDbConnection (breaking)
  - Add net8.0 target framework alongside netstandard2.0/2.1
  - Update test project from netcoreapp3.1 to net8.0 with latest MSTest 3.x
  - Fix test LocalDB attachment by using AppContext.BaseDirectory
  - Add GitHub Actions CI workflow
  - Improve README with install instructions, usage examples, and migration guide

  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>